### PR TITLE
Basic support for undef values

### DIFF
--- a/lib/Chart/Clicker/Axis.pm
+++ b/lib/Chart/Clicker/Axis.pm
@@ -508,6 +508,7 @@ Given a span and a value, returns it's pixel position on this Axis.
 
 sub mark {
     my ($self, $span, $value) = @_;
+    return undef if not defined $value;
 
     if($self->has_skip_range) {
         # We must completely ignore values that fall inside the skip range,

--- a/lib/Chart/Clicker/Data/Series.pm
+++ b/lib/Chart/Clicker/Data/Series.pm
@@ -110,7 +110,7 @@ Get the count of values in this series.
 has 'values' => (
     traits => [ 'Array' ],
     is => 'rw',
-    isa => 'ArrayRef[Num]',
+    isa => 'ArrayRef',
     default => sub { [] },
     handles => {
         'add_to_values' => 'push',
@@ -127,7 +127,7 @@ sub _build_range {
         unless scalar(@{ $values });
 
     return Chart::Clicker::Data::Range->new(
-        lower => min(@{ $values }), upper => max(@{ $values})
+        lower => min(grep { defined } @{ $values }), upper => max(grep { defined } @{ $values})
     );
 }
 


### PR DESCRIPTION
Hi, I'm trying out Chart::Clicker as a replacement for the ancient Chart module, and so far it looks great, except that it doesn't handle series with missing values.  This might be needed, for example, if you have two share prices to plot but there is no price for one of them on a given day because of a holiday.  This patch adds the minimal support for series with undef values to be handed; when drawing a line chart the line will go unbroken from the previous to the next observation, which is good enough.  I may add more sophisticated support for series with missing values later.

Let me know what you think and whether you're willing to apply the patch and add this functionality.
