### PR TITLE
Fixed Moose enum warnings

### DIFF
--- a/lib/Chart/Clicker/Positioned.pm
+++ b/lib/Chart/Clicker/Positioned.pm
@@ -5,7 +5,7 @@ use Moose::Role;
 
 use Moose::Util::TypeConstraints;
 
-enum 'Chart::Clicker::Position' => qw(left right top bottom);
+enum 'Chart::Clicker::Position' => [qw(left right top bottom)];
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
This fixes the warnings produced by the change to the way enum should be called. Below is a blurb the Moose guys have been distributing.

---

We recently changed the syntax of enum declarations in Moose types. It appears that your module is affected. You can read more about the change here: https://metacpan.org/pod/release/ETHER/Moose-2.1106-TRIAL/lib/Moose/Manual/Delta.pod#pod2.1200 We recommend that you take a look at your code to see if it indeed does need to be updated with respect to the latest Moose release, 2.1106-TRIAL. If you have any questions, then please ask either on Moose mailing list : http://lists.perl.org/list/moose.html or on #moose & #moose-dev on irc.perl.org.
