### PR TITLE
fix overaxis height

### DIFF
--- a/lib/Chart/Clicker/Decoration/OverAxis.pm
+++ b/lib/Chart/Clicker/Decoration/OverAxis.pm
@@ -165,6 +165,7 @@ override('finalize', sub {
     $self->border->top->width($self->border_width);
     $self->border->bottom->width($self->border_width);
     $self->border->color($self->border_color);
+    $self->minimum_height($self->axis_height);
     $self->height($self->axis_height);
 
     my $ticks = $domain->tick_values;


### PR DESCRIPTION
Now example/overaxis-bar.pl has a problem that the overaxis takes the whole bottom half of the plot. 

Somehow before calling do_layout of the Layout::Manager::Compass object, the container's height seems to be around the default height of the plot. Then in Layout::Manager::Compass it sets minimum_height to that large number and this prevents `$self->height($self->axis_height);` from taking effect in finalize of Chart/Clicker/Decoration/OverAxis.pm. 

This patch is to fix this issue. 
